### PR TITLE
Fix SSR missing generated classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-daisyui-rs"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "leptos",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leptos-daisyui-rs"
 description = "daisyUI Components for Leptos"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 license = "MIT"
 authors = ["noshishiRust <nopenoshishi@gmail.com>"]

--- a/src/utils/class_attribute.rs
+++ b/src/utils/class_attribute.rs
@@ -70,8 +70,8 @@ impl IntoClass for ClassAttributes {
         self.values.len()
     }
 
-    fn to_html(self, _class: &mut String) {
-        self.to_class();
+    fn to_html(self, class: &mut String) {
+        *class = self.to_class();
     }
 
     fn hydrate<const FROM_SERVER: bool>(self, el: &types::Element) -> Self::State {


### PR DESCRIPTION
ClassAttribute would previously discard the class names instead of updating the HTML node when converting the ClassAttribute to HTML. This mechanism is used during SSR to generate the HTML document; the issue likely went unnoticed since client-side Hydration uses a different mechanism.