### PR TITLE
Fix RadialProgress style attribute syntax

### DIFF
--- a/src/components/radial_progress/component.rs
+++ b/src/components/radial_progress/component.rs
@@ -53,8 +53,8 @@ pub fn RadialProgress(
             }
 
             aria-valuenow=value
-            style=("--value", move || value.get().to_string())
-            style=("--thickness", move || thickness.get())
+            style:--value=move || value.get().to_string()
+            style:--thickness=move || thickness.get()
         >
             {children.map(|v| v())}
         </div>


### PR DESCRIPTION
Use style: directive instead of style= tuple format for CSS custom properties. This fixes compilation error E0277 in Leptos 0.8.

The previous syntax using style=(\--value\, ...) is invalid in Leptos 0.8. Changed to style:--value=... and style:--thickness=... which is the correct syntax for setting CSS custom properties reactively.

Fixes: Compilation failure preventing library from being used
Impact: Critical - library now compiles successfully