### PR TITLE
Fix Link component href default to prevent page scroll

### DIFF
--- a/src/components/link/component.rs
+++ b/src/components/link/component.rs
@@ -39,10 +39,12 @@ pub fn Link(
     /// Text content of the link
     children: Children,
 ) -> impl IntoView {
+    let href_value = href.unwrap_or("javascript:void(0)");
+
     view! {
         <a
             node_ref=node_ref
-            href=href.unwrap_or("#")
+            href=href_value
             class=move || {
                 merge_classes!("link",
                 color.get().as_str(),


### PR DESCRIPTION
Changed default href from \"#\" to \"javascript:void(0)\" to prevent unwanted page scrolling and URL pollution when href prop is None.

Previous behavior:
- href.unwrap_or(\"#\") caused page to jump to top
- Added unwanted # to URL
- Created confusing UX in SPAs

New behavior:
- javascript:void(0) prevents navigation
- No page scroll
- No URL changes
- Standard practice for non-navigating links

Fixes: Unwanted page scroll when Link has no href
Impact: Better UX, no breaking changes