### PR TITLE
feat: add CSS auto-setup via library API and CLI css command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,24 @@ The library uses Tailwind CSS v4 with daisyUI plugin. CSS classes are inlined us
 
 All daisyUI classes are available in `stytles/daisyui-components.css` for full inclusion.
 
+### CSS Auto-Setup
+
+The library exposes a `css` module (`src/css.rs`) providing programmatic access to `@source inline()` directives:
+
+- `FULL_CSS` — Complete CSS file content (header + all directives)
+- `source_directives_only()` — Directives only, excluding the `@import`/`@plugin` header
+
+The `stytles/daisyui-components.css` file uses a `/* === leptos-daisyui-rs @source directives === */` marker to separate the header from directives. The `source_directives_only()` function locates this marker to split content.
+
+The CLI provides a `css` command for managing directives in user projects:
+
+```bash
+leptos-daisyui css --all          # All components
+leptos-daisyui css button card    # Specific components
+```
+
+**Important**: `@source inline()` is a Tailwind CSS build-time directive. It must be in a CSS file processed by Tailwind at build time. Runtime `<style>` tag injection does NOT work.
+
 ## Documentation System
 
 Component documentation in `doc/components/` follows a structured format:
@@ -149,6 +167,8 @@ When adding a new daisyUI component:
 2. Implement `mod.rs`, `component.rs`, `style.rs` following existing patterns
 3. Export from `src/components/mod.rs`
 4. Add CSS classes to documentation comment
-5. Add markdown documentation in `doc/components/{component_name}.md`
-6. Run `leptosfmt .` to format
-7. Update `README.md` implementation table
+5. Add `@source inline()` directive to `stytles/daisyui-components.css` (after the marker)
+6. Update `component_metadata.json` in the CLI with the new component's CSS classes
+7. Add markdown documentation in `doc/components/{component_name}.md`
+8. Run `leptosfmt .` to format
+9. Update `README.md` implementation table

--- a/README.md
+++ b/README.md
@@ -54,8 +54,18 @@ npm install
 # Browse all available components
 leptos-daisyui list --all
 
-# Add one or more components
+# Add one or more components (copies source files + updates CSS)
 leptos-daisyui add button card alert
+```
+
+If you only need CSS directives without copying component source files:
+
+```sh
+# Add CSS for specific components
+leptos-daisyui css button card
+
+# Or add CSS for all components at once
+leptos-daisyui css --all
 ```
 
 #### 4. Register the generated module
@@ -124,7 +134,17 @@ Add CSS classes for each component you use to your `input.css`:
 @source inline("collapse collapse-title collapse-content collapse-arrow collapse-plus collapse-open collapse-close");
 ```
 
-To include all daisyUI classes at once, see [daisyui-components.css](./stytles/daisyui-components.css).
+To include all daisyUI classes at once, use the library's `css` module in your `build.rs`:
+
+```rust,ignore
+// build.rs
+fn main() {
+    let css = leptos_daisyui_rs::css::source_directives_only();
+    std::fs::write("daisyui-classes.css", css).unwrap();
+}
+```
+
+Or see the complete list in [daisyui-components.css](./stytles/daisyui-components.css).
 
 > Note: Including all classes increases CSS bundle size. The `@source inline()` approach is recommended for production.
 

--- a/leptos-daisyui-cli/src/commands/add.rs
+++ b/leptos-daisyui-cli/src/commands/add.rs
@@ -85,7 +85,8 @@ fn add_component(
     println!("  {} Updated generated/mod.rs", "✓".green());
 
     // Add CSS classes to input.css
-    add_css_classes(project, metadata)?;
+    let input_css = CssManager::find_input_css_in(project.root())?;
+    CssManager::append_directive(&input_css, &metadata.display_name, &metadata.css_classes)?;
     println!("  {} Added CSS classes to input.css", "✓".green());
 
     Ok(())
@@ -110,58 +111,4 @@ fn update_generated_mod(generated_dir: &std::path::Path, component_name: &str) -
     fs::write(&mod_rs, content).with_context(|| format!("Failed to write {}", mod_rs.display()))?;
 
     Ok(())
-}
-
-fn add_css_classes(
-    project: &crate::project::ProjectStructure,
-    metadata: &crate::component::ComponentMetadata,
-) -> Result<()> {
-    let root = project.root();
-    let input_css = find_input_css(root)?;
-
-    let mut content = fs::read_to_string(&input_css)
-        .with_context(|| format!("Failed to read {}", input_css.display()))?;
-
-    // Define markers
-    let marker_start = "/* === leptos-daisyui-cli managed - do not edit manually === */";
-    let marker_end = "/* === end leptos-daisyui-cli managed === */";
-
-    // Component CSS entry
-    let component_css = format!(
-        "/* {} */\n@source inline(\"{}\");",
-        metadata.display_name, metadata.css_classes
-    );
-
-    // Check if component already added
-    if content.contains(&format!("/* {} */", metadata.display_name)) {
-        return Ok(());
-    }
-
-    // Find managed section
-    if let Some(start_idx) = content.find(marker_start) {
-        if let Some(end_idx) = content.find(marker_end) {
-            // Insert before end marker
-            let insert_pos = end_idx;
-            content.insert_str(insert_pos, &format!("{}\n", component_css));
-        } else {
-            // Start marker exists but no end marker - append after start
-            let insert_pos = start_idx + marker_start.len();
-            content.insert_str(insert_pos, &format!("\n{}\n{}", component_css, marker_end));
-        }
-    } else {
-        // No managed section - create one at the end
-        content.push_str(&format!(
-            "\n{}\n{}\n{}\n",
-            marker_start, component_css, marker_end
-        ));
-    }
-
-    fs::write(&input_css, content)
-        .with_context(|| format!("Failed to write {}", input_css.display()))?;
-
-    Ok(())
-}
-
-fn find_input_css(root: &std::path::Path) -> Result<std::path::PathBuf> {
-    CssManager::find_input_css_in(root)
 }

--- a/leptos-daisyui-cli/src/commands/css.rs
+++ b/leptos-daisyui-cli/src/commands/css.rs
@@ -1,0 +1,104 @@
+use crate::component::ComponentRegistry;
+use crate::css::CssManager;
+use crate::project::ProjectDetector;
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::env;
+
+/// Manage CSS `@source inline()` directives for daisyUI components.
+///
+/// This command modifies `input.css` (or equivalent) to include Tailwind CSS v4
+/// `@source inline()` directives for the specified components. These directives
+/// tell Tailwind CSS which daisyUI classes to generate during build.
+///
+/// Note: This command only needs the component metadata (CSS class strings),
+/// not the full component source files. It is lighter than the `add` command.
+pub fn execute(components: Vec<String>, all: bool) -> Result<()> {
+    let registry = ComponentRegistry::load()?;
+    let current_dir = env::current_dir()?;
+    let project = ProjectDetector::detect(&current_dir)
+        .context("Failed to detect project. Run 'leptos-daisyui init' first.")?;
+
+    let input_css = CssManager::find_input_css_in(project.root())?;
+
+    if all {
+        add_all_components(&registry, &input_css)?;
+    } else if components.is_empty() {
+        anyhow::bail!(
+            "Specify component names or use {} for all components",
+            "--all".bold()
+        );
+    } else {
+        for name in &components {
+            add_single_component(&registry, &input_css, name)?;
+        }
+    }
+
+    println!();
+    println!(
+        "{} CSS directives updated in {}",
+        "✓".green(),
+        input_css.display()
+    );
+
+    Ok(())
+}
+
+fn add_all_components(registry: &ComponentRegistry, input_css: &std::path::Path) -> Result<()> {
+    let mut added = 0;
+    let mut skipped = 0;
+
+    for metadata in registry.all() {
+        if CssManager::has_component(input_css, &metadata.display_name)? {
+            skipped += 1;
+            continue;
+        }
+        CssManager::append_directive(input_css, &metadata.display_name, &metadata.css_classes)?;
+        added += 1;
+    }
+
+    if added > 0 {
+        println!(
+            "{} Added CSS for {} components",
+            "✓".green(),
+            added.to_string().bold()
+        );
+    }
+    if skipped > 0 {
+        println!(
+            "{} Skipped {} already present",
+            "-".yellow(),
+            skipped.to_string().bold()
+        );
+    }
+
+    Ok(())
+}
+
+fn add_single_component(
+    registry: &ComponentRegistry,
+    input_css: &std::path::Path,
+    component_name: &str,
+) -> Result<()> {
+    let metadata = registry
+        .get(component_name)
+        .ok_or_else(|| anyhow::anyhow!("Component '{}' not found", component_name))?;
+
+    if CssManager::has_component(input_css, &metadata.display_name)? {
+        println!(
+            "  {} CSS for {} already present",
+            "-".yellow(),
+            metadata.display_name.bold()
+        );
+        return Ok(());
+    }
+
+    CssManager::append_directive(input_css, &metadata.display_name, &metadata.css_classes)?;
+    println!(
+        "  {} Added CSS for {}",
+        "✓".green(),
+        metadata.display_name.bold()
+    );
+
+    Ok(())
+}

--- a/leptos-daisyui-cli/src/commands/mod.rs
+++ b/leptos-daisyui-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod add;
+pub mod css;
 pub mod init;
 pub mod list;

--- a/leptos-daisyui-cli/src/css/manager.rs
+++ b/leptos-daisyui-cli/src/css/manager.rs
@@ -1,5 +1,10 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::fs;
 use std::path::{Path, PathBuf};
+
+/// Managed section markers for leptos-daisyui-cli CSS directives
+const MARKER_START: &str = "/* === leptos-daisyui-cli managed - do not edit manually === */";
+const MARKER_END: &str = "/* === end leptos-daisyui-cli managed === */";
 
 #[allow(dead_code)]
 pub struct CssManager {
@@ -20,7 +25,6 @@ impl CssManager {
 
     /// Find input.css file in common locations (static method)
     pub fn find_input_css_in(root: &Path) -> Result<PathBuf> {
-        // Common locations
         let candidates = vec![
             root.join("input.css"),
             root.join("src/input.css"),
@@ -36,5 +40,53 @@ impl CssManager {
 
         // If not found, use default location
         Ok(root.join("input.css"))
+    }
+
+    /// Check if a specific component's CSS is already in the managed section.
+    pub fn has_component(input_css: &Path, display_name: &str) -> Result<bool> {
+        let content = fs::read_to_string(input_css)
+            .with_context(|| format!("Failed to read {}", input_css.display()))?;
+        Ok(content.contains(&format!("/* {} */", display_name)))
+    }
+
+    /// Append a CSS directive for a component to the managed section of input.css.
+    ///
+    /// Creates the managed section if it doesn't exist. Skips if the component
+    /// is already present.
+    pub fn append_directive(input_css: &Path, display_name: &str, css_classes: &str) -> Result<()> {
+        // Skip if already present
+        if Self::has_component(input_css, display_name)? {
+            return Ok(());
+        }
+
+        let mut content = fs::read_to_string(input_css)
+            .with_context(|| format!("Failed to read {}", input_css.display()))?;
+
+        let component_css = format!(
+            "/* {} */\n@source inline(\"{}\");",
+            display_name, css_classes
+        );
+
+        if let Some(start_idx) = content.find(MARKER_START) {
+            if let Some(end_idx) = content.find(MARKER_END) {
+                // Insert before end marker
+                content.insert_str(end_idx, &format!("{}\n", component_css));
+            } else {
+                // Start marker exists but no end marker - append after start
+                let insert_pos = start_idx + MARKER_START.len();
+                content.insert_str(insert_pos, &format!("\n{}\n{}", component_css, MARKER_END));
+            }
+        } else {
+            // No managed section - create one at the end
+            content.push_str(&format!(
+                "\n{}\n{}\n{}\n",
+                MARKER_START, component_css, MARKER_END
+            ));
+        }
+
+        fs::write(input_css, content)
+            .with_context(|| format!("Failed to write {}", input_css.display()))?;
+
+        Ok(())
     }
 }

--- a/leptos-daisyui-cli/src/main.rs
+++ b/leptos-daisyui-cli/src/main.rs
@@ -46,6 +46,16 @@ enum Commands {
         #[arg(short, long)]
         interactive: bool,
     },
+
+    /// Manage CSS @source inline() directives
+    Css {
+        /// Component names to add CSS for
+        components: Vec<String>,
+
+        /// Add CSS for all components
+        #[arg(long)]
+        all: bool,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -64,6 +74,9 @@ fn main() -> anyhow::Result<()> {
             interactive,
         } => {
             commands::add::execute(components, force, interactive)?;
+        }
+        Commands::Css { components, all } => {
+            commands::css::execute(components, all)?;
         }
     }
 

--- a/leptos-daisyui-rs/src/css.rs
+++ b/leptos-daisyui-rs/src/css.rs
@@ -1,0 +1,82 @@
+//! CSS auto-setup utilities for leptos-daisyui-rs
+//!
+//! Provides Tailwind CSS v4 `@source inline()` directives for all
+//! daisyUI component classes. These directives must be placed in a
+//! CSS file that Tailwind CSS processes at build time.
+//!
+//! ## Important
+//!
+//! These directives are **build-time** directives for Tailwind CSS v4.
+//! They must be placed in a CSS file (e.g., `input.css`) that the
+//! Tailwind CSS CLI processes before your application runs.
+//! Do NOT inject these into `<style>` tags at runtime — the browser
+//! cannot process `@source inline()` directives.
+
+/// The complete CSS file content including the Tailwind header and all
+/// `@source inline()` directives for every daisyUI component.
+///
+/// This is the full content of `stytles/daisyui-components.css`,
+/// which includes the `@import "tailwindcss"` and `@plugin "daisyui"`
+/// header followed by per-component directives.
+pub const FULL_CSS: &str = include_str!("../stytles/daisyui-components.css");
+
+/// Returns only the per-component `@source inline()` directives,
+/// without the `@import "tailwindcss"` and `@plugin "daisyui"` header.
+///
+/// Use this when you already have the Tailwind header in your CSS file
+/// and only need to add the daisyUI component class directives.
+///
+/// ## Example usage in `build.rs`
+///
+/// ```rust,ignore
+/// fn main() {
+///     let css_path = std::path::PathBuf::from("daisyui-classes.css");
+///     std::fs::write(&css_path, leptos_daisyui::css::source_directives_only()).unwrap();
+/// }
+/// ```
+pub fn source_directives_only() -> &'static str {
+    const FULL: &str = include_str!("../stytles/daisyui-components.css");
+    // The file starts with:
+    //   @import "tailwindcss";     (line 1)
+    //   @plugin "daisyui";         (line 2)
+    //   <blank>                    (line 3)
+    //   /* Accordion */            (line 4)
+    // We return everything from the first component comment onward.
+    match FULL.find("/* Accordion */") {
+        Some(idx) => &FULL[idx..],
+        None => FULL,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_css_contains_header() {
+        assert!(FULL_CSS.contains("@import \"tailwindcss\""));
+        assert!(FULL_CSS.contains("@plugin \"daisyui\""));
+    }
+
+    #[test]
+    fn full_css_contains_all_components() {
+        assert!(FULL_CSS.contains("@source inline(\"btn"));
+        assert!(FULL_CSS.contains("@source inline(\"card"));
+        assert!(FULL_CSS.contains("@source inline(\"modal"));
+    }
+
+    #[test]
+    fn source_directives_excludes_header() {
+        let directives = source_directives_only();
+        assert!(!directives.contains("@import \"tailwindcss\""));
+        assert!(!directives.contains("@plugin \"daisyui\""));
+    }
+
+    #[test]
+    fn source_directives_contains_components() {
+        let directives = source_directives_only();
+        assert!(directives.contains("/* Accordion */"));
+        assert!(directives.contains("@source inline(\"btn"));
+        assert!(directives.contains("@source inline(\"card"));
+    }
+}

--- a/leptos-daisyui-rs/src/css.rs
+++ b/leptos-daisyui-rs/src/css.rs
@@ -20,6 +20,9 @@
 /// header followed by per-component directives.
 pub const FULL_CSS: &str = include_str!("../stytles/daisyui-components.css");
 
+/// Marker comment that precedes the @source directives in daisyui-components.css.
+const SOURCE_DIRECTIVES_MARKER: &str = "/* === leptos-daisyui-rs @source directives === */";
+
 /// Returns only the per-component `@source inline()` directives,
 /// without the `@import "tailwindcss"` and `@plugin "daisyui"` header.
 ///
@@ -36,13 +39,7 @@ pub const FULL_CSS: &str = include_str!("../stytles/daisyui-components.css");
 /// ```
 pub fn source_directives_only() -> &'static str {
     const FULL: &str = include_str!("../stytles/daisyui-components.css");
-    // The file starts with:
-    //   @import "tailwindcss";     (line 1)
-    //   @plugin "daisyui";         (line 2)
-    //   <blank>                    (line 3)
-    //   /* Accordion */            (line 4)
-    // We return everything from the first component comment onward.
-    match FULL.find("/* Accordion */") {
+    match FULL.find(SOURCE_DIRECTIVES_MARKER) {
         Some(idx) => &FULL[idx..],
         None => FULL,
     }
@@ -75,6 +72,7 @@ mod tests {
     #[test]
     fn source_directives_contains_components() {
         let directives = source_directives_only();
+        assert!(directives.contains(SOURCE_DIRECTIVES_MARKER));
         assert!(directives.contains("/* Accordion */"));
         assert!(directives.contains("@source inline(\"btn"));
         assert!(directives.contains("@source inline(\"card"));

--- a/leptos-daisyui-rs/src/lib.rs
+++ b/leptos-daisyui-rs/src/lib.rs
@@ -2,4 +2,5 @@
 #![doc = include_str!("../README.md")]
 
 pub mod components;
+pub mod css;
 pub mod utils;

--- a/leptos-daisyui-rs/stytles/daisyui-components.css
+++ b/leptos-daisyui-rs/stytles/daisyui-components.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @plugin "daisyui";
 
+/* === leptos-daisyui-rs @source directives === */
 /* Accordion */
 @source inline("collapse collapse-title collapse-content collapse-arrow collapse-plus collapse-open collapse-close");
 /* Alert */


### PR DESCRIPTION
## Summary

- **Library**: Add `css` module exposing `FULL_CSS` and `source_directives_only()` so users can programmatically access Tailwind CSS v4 `@source inline()` directives
- **CLI**: Add `css` subcommand to manage CSS directives without copying component source files (e.g., `leptos-daisyui css --all` or `leptos-daisyui css button card`)
- **Refactor**: Extract managed-section logic into `CssManager` and reuse it from both `add` and `css` commands

### Key design decision

The original issue #18 proposed runtime `<style>` tag injection via `include_str!`. This approach **does not work** with Tailwind CSS v4 because `@source inline()` is a build-time directive — the browser cannot process it. The correct mechanism is placing `@source inline()` directives in a CSS file that Tailwind processes during build (via `trunk` / `npx tailwindcss`).

### Binary size

The new `css` command only uses `ComponentRegistry` (25KB JSON) and does **not** depend on `rust-embed` (676KB of component sources), making it significantly lighter than the `add` command.

Closes #18

## Test plan

- [x] `cargo test -p leptos-daisyui-rs` — 4 new CSS module tests pass
- [x] `leptosfmt --check .` — formatting clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo build -p leptos-daisyui-cli` — builds successfully
- [ ] Manual: run `leptos-daisyui css --all` in a test project and verify `input.css` is updated
- [ ] Manual: verify demo app still renders correctly after regenerating CSS directives