### PR TITLE
fix: guard non-Rust code blocks and improve parse error messages

### DIFF
--- a/demo-macros/src/markdown/code_block.rs
+++ b/demo-macros/src/markdown/code_block.rs
@@ -11,18 +11,16 @@
 //!
 //! ## Behavior
 //!
-//! 1. Extract code block literal content
-//! 2. **TODO**: Check for language identifier (e.g., \`\`\`rust)
-//! 3. Parse as Rust TokenStream
-//! 4. Wrap in `<div>` container
-//! 5. Include in generated view
+//! 1. Check language identifier — only `""` (empty) and `"rust"` are accepted
+//! 2. Non-Rust code blocks are silently skipped (empty token stream)
+//! 3. Parse accepted blocks as Rust TokenStream
+//! 4. On parse failure, emit `compile_error!` with the offending code and error details
+//! 5. Wrap in `<div>` container
 //!
 //! ## Limitations
 //!
-//! - **TODO**: Language identifier (`info`) is parsed but not used or validated
-//! - **TODO**: No syntax highlighting or code display mode (always executes)
-//! - **TODO**: No error context if parsing fails - just panics
-//! - **TODO**: Should support non-Rust code blocks with proper escaping/display
+//! - No syntax highlighting or code display mode (always executes)
+//! - No line numbers or copy button functionality
 
 use comrak::nodes::{AstNode, NodeCodeBlock};
 use proc_macro2::TokenStream;
@@ -63,49 +61,42 @@ use quote::quote;
 ///
 /// # Panics
 ///
-/// - **TODO**: Panics if code block contains invalid Rust syntax
-/// - Should provide better error messages showing which line/column failed
+/// This function does not panic. Invalid Rust code blocks produce a `compile_error!`
+/// at the macro invocation site with the offending code and parse error details.
 ///
 /// # Language Identifier
 ///
-/// **TODO**: The `info` field contains the language identifier (e.g., "rust", "javascript").
-/// This is currently extracted but not validated or used. Future improvements:
-///
-/// ```ignore
-/// let info = code_block_node.info.clone();
-/// if !info.is_empty() && info != "rust" {
-///     // Either escape for display or emit compile-time warning
-///     compile_error!("Only Rust code blocks are supported");
-/// }
-/// ```
+/// The `info` field is validated to ensure only Rust code blocks are processed:
+/// - `""` (empty) — accepted (indented or un-annotated fenced blocks)
+/// - `"rust"` — accepted explicitly
+/// - Any other value (e.g., `"html"`, `"css"`) — silently skipped (empty token stream)
 pub fn token_stream_for_view<'a>(
     _node: &'a AstNode<'a>,
     code_block_node: &NodeCodeBlock,
 ) -> TokenStream {
-    // Extract language identifier (e.g., "rust", "js", "toml")
-    // **TODO**: This is currently extracted but not used. Should:
-    // 1. Validate that it's "rust" (or empty/default)
-    // 2. Emit compile warning if non-rust code is found
-    // 3. Consider supporting other languages with proper escaping
-    let _info = code_block_node.info.clone();
+    let info = code_block_node.info.clone();
 
-    // Extract the actual code content
+    // Skip non-Rust code blocks silently. Accept both empty (indented or
+    // un-annotated fenced blocks) and "rust" explicitly.
+    if !info.is_empty() && info != "rust" {
+        return quote! {};
+    }
+
     let code = code_block_node.literal.clone();
 
-    // **TODO**: Add better error handling for parse failures
-    // Current panic message is not helpful:
-    //   "Failed to convert stream from string"
-    // Better:
-    //   "Failed to parse Rust code in markdown: {code}\nError: {error}"
-    let code_raw_stream = code
-        .parse::<TokenStream>()
-        .expect("Failed to convert stream from string");
+    let code_raw_stream = match code.parse::<TokenStream>() {
+        Ok(stream) => stream,
+        Err(e) => {
+            let msg = format!(
+                "failed to parse Rust code block as valid TokenStream:\n--- code ---\n{}\n--- error ---\n{}",
+                code, e
+            );
+            return quote! {
+                compile_error!(#msg);
+            };
+        }
+    };
 
-    // Wrap code in a div for container
-    // **TODO**: Consider adding classes for styling:
-    // - class="demo-code-block" for styling hooks
-    // - Add line numbers option
-    // - Add copy button functionality
     quote! {
         <div>
             #code_raw_stream


### PR DESCRIPTION
## Summary

- Validate the `info` field of markdown code blocks to accept only `""` (empty) or `"rust"` language identifiers, silently skipping non-Rust blocks (e.g., `html`, `css`)
- Replace the panic on `TokenStream` parse failure with a `compile_error!` that includes the offending code and parse error details for easier debugging
- Update doc comments to remove resolved TODOs and reflect the implemented behavior

Closes #20

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] Verify existing demo components render correctly with `trunk serve`
- [ ] (Manual) Confirm that a markdown file with a non-Rust code block (e.g., ` ```html `) compiles without error and the block is skipped